### PR TITLE
fixed issue https://notepad-plus-plus.org/community/topic/12558 + appveyor + x64 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ X=src\xml
 
 # http://msdn.microsoft.com/en-us/library/fwkeyyhe.aspx
 CXX=cl
-CXXFLAGS=/O2 /EHs /GR- /MT /nologo /W3 /WX- /Gd /Gm- /Fo$O\ /fp:fast /wd4995 \
+CXXFLAGS=/O2 /EHs /GR- /MT /nologo /W3 /WX- /Gd /Gm- /Fo$O\ /fp:fast \
          /errorReport:none /Zc:wchar_t /DWIN32 /DNDEBUG /D_WINDOWS /D_USRDLL \
          /D_WINDLL /DUNICODE /D_UNICODE /c
 
@@ -24,7 +24,7 @@ CXXFLAGS=/O2 /EHs /GR- /MT /nologo /W3 /WX- /Gd /Gm- /Fo$O\ /fp:fast /wd4995 \
 LD=link
 LIBS=user32.lib shell32.lib
 LDFLAGS=/DLL /nologo /OUT:$O\$(PRJ).dll /INCREMENTAL:NO /MANIFEST:NO \
-        /MACHINE:X86 /ERRORREPORT:NONE
+        /ERRORREPORT:NONE
 
 RC=rc
 RCFLAGS=/nologo /fo$O\$(PRJ).res

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,53 @@
+version: 1.4.3.{build}
+image: Visual Studio 2017
+
+environment:
+    matrix:
+      - PlatformToolset: v140_xp
+      #- PlatformToolset: v141_xp
+
+platform:
+    - x64
+    - x86
+
+configuration:
+    - Release
+    #- Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x86" set archi=x86
+    - if "%PlatformToolset%"=="v140_xp" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - nmake
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+        Push-AppveyorArtifact "obj\SessionMgr.dll" -FileName SessionMgr.dll
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
+            $ZipFileName = "SessionMgr_$($env:APPVEYOR_REPO_TAG_NAME)_$env:PLATFORM.zip"
+            7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\obj\SessionMgr.dll"
+            7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\doc"
+        }
+
+artifacts:
+  - path: SessionMgr_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: PhNXrhw03Z0rJZssX/UYyoIofw669wU1GBy/hGq+WJPCXd7mbxDu6Il32Rx0LBH6
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140_xp
+        configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,15 @@
 version: 1.4.3.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
     matrix:
-      - PlatformToolset: v140_xp
-      #- PlatformToolset: v141_xp
+      - PlatformToolset: v141_xp
+      - PlatformToolset: v142
 
 platform:
     - x64
     - x86
+    - arm64
 
 configuration:
     - Release
@@ -17,8 +18,10 @@ configuration:
 install:
     - if "%platform%"=="x64" set archi=amd64
     - if "%platform%"=="x86" set archi=x86
-    - if "%PlatformToolset%"=="v140_xp" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%platform%"=="arm64" set archi=amd64_arm64
+
     - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v142" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
@@ -29,7 +32,7 @@ after_build:
     - ps: >-
         Push-AppveyorArtifact "obj\SessionMgr.dll" -FileName SessionMgr.dll
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140_xp") {
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141_xp") {
             $ZipFileName = "SessionMgr_$($env:APPVEYOR_REPO_TAG_NAME)_$env:PLATFORM.zip"
             7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\obj\SessionMgr.dll"
             7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\doc"
@@ -49,5 +52,5 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: v140_xp
+        PlatformToolset: v141_xp
         configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
-version: 1.4.3.{build}
+version: 1.4.4.{build}
 image: Visual Studio 2019
 
 environment:
     matrix:
-      - PlatformToolset: v141_xp
       - PlatformToolset: v142
 
 platform:
@@ -20,7 +19,6 @@ install:
     - if "%platform%"=="x86" set archi=x86
     - if "%platform%"=="arm64" set archi=amd64_arm64
 
-    - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
     - if "%PlatformToolset%"=="v142" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build_script:
@@ -32,7 +30,7 @@ after_build:
     - ps: >-
         Push-AppveyorArtifact "obj\SessionMgr.dll" -FileName SessionMgr.dll
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141_xp") {
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v142") {
             $ZipFileName = "SessionMgr_$($env:APPVEYOR_REPO_TAG_NAME)_$env:PLATFORM.zip"
             7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\obj\SessionMgr.dll"
             7z a $ZipFileName "$($env:APPVEYOR_BUILD_FOLDER)\doc"
@@ -52,5 +50,5 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: v141_xp
+        PlatformToolset: v142
         configuration: Release

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -68,7 +68,7 @@ extern "C" __declspec(dllexport) void setInfo(NppData nppd)
 
 extern "C" __declspec(dllexport) LPCWSTR getName()
 {
-    return app_getName();
+    return PLUGIN_FULL_NAME;
 }
 
 extern "C" __declspec(dllexport) FuncItem* getFuncsArray(INT *pnbFuncItems)

--- a/src/Properties.cpp
+++ b/src/Properties.cpp
@@ -284,7 +284,7 @@ void updateSessionFromGlobal(LPWSTR sesFile)
 /** Updates document properties from global file properties.
     When an existing document is added to a session, its bookmarks and
     firstVisibleLine are updated from the global properties. */
-void updateDocumentFromGlobal(INT bufferId)
+void updateDocumentFromGlobal(LRESULT bufferId)
 {
     LPSTR mbPathname;
     WCHAR pathname[MAX_PATH];

--- a/src/Properties.h
+++ b/src/Properties.h
@@ -36,7 +36,7 @@ namespace prp {
 
 void updateGlobalFromSession(LPWSTR sesFile);
 void updateSessionFromGlobal(LPWSTR sesFile);
-void updateDocumentFromGlobal(INT bufferId);
+void updateDocumentFromGlobal(LRESULT bufferId);
 
 } // end namespace NppPlugin::prp
 

--- a/src/SessionMgr.cpp
+++ b/src/SessionMgr.cpp
@@ -41,8 +41,8 @@ vector<Session> _sessions; ///< stores info on sessions read from disk
 INT _sesCurIdx;            ///< current session index
 INT _sesPrvIdx;            ///< previous session index
 INT _sesDefIdx;            ///< default session index
-INT _bidFileOpened;        ///< bufferId from most recent NPPN_FILEOPENED
-INT _bidBufferActivated;   ///< XXX experimental. bufferId from most recent NPPN_BUFFERACTIVATED
+LRESULT _bidFileOpened;        ///< bufferId from most recent NPPN_FILEOPENED
+LRESULT _bidBufferActivated;   ///< XXX experimental. bufferId from most recent NPPN_BUFFERACTIVATED
 bool _appReady;            ///< if false, plugin should do nothing
 bool _sesLoading;          ///< if true, a session is loading
 bool _fileOpenedFromCmdLine;

--- a/src/npp/Notepad_plus_msgs.h
+++ b/src/npp/Notepad_plus_msgs.h
@@ -7,10 +7,10 @@
 // version 2 of the License, or (at your option) any later version.
 //
 // Note that the GPL places important restrictions on "derived works", yet
-// it does not provide a detailed definition of that term.  To avoid      
-// misunderstandings, we consider an application to constitute a          
+// it does not provide a detailed definition of that term.  To avoid
+// misunderstandings, we consider an application to constitute a
 // "derivative work" for the purpose of this license if it does any of the
-// following:                                                             
+// following:
 // 1. Integrates source code from Notepad++.
 // 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
 //    installer, such as those produced by InstallShield.
@@ -29,22 +29,26 @@
 #ifndef NOTEPAD_PLUS_MSGS_H
 #define NOTEPAD_PLUS_MSGS_H
 
+#include <windows.h>
+#include <tchar.h>
 
 enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_HTML, L_XML, L_MAKEFILE, L_PASCAL, L_BATCH, L_INI, L_ASCII, L_USER,\
-			   L_ASP, L_SQL, L_VB, L_JS, L_CSS, L_PERL, L_PYTHON, L_LUA,\
+			   L_ASP, L_SQL, L_VB, L_JS, L_CSS, L_PERL, L_PYTHON, L_LUA, \
 			   L_TEX, L_FORTRAN, L_BASH, L_FLASH, L_NSIS, L_TCL, L_LISP, L_SCHEME,\
 			   L_ASM, L_DIFF, L_PROPS, L_PS, L_RUBY, L_SMALLTALK, L_VHDL, L_KIX, L_AU3,\
 			   L_CAML, L_ADA, L_VERILOG, L_MATLAB, L_HASKELL, L_INNO, L_SEARCHRESULT,\
 			   L_CMAKE, L_YAML, L_COBOL, L_GUI4CLI, L_D, L_POWERSHELL, L_R, L_JSP,\
-			   L_COFFEESCRIPT,\
+			   L_COFFEESCRIPT, L_JSON, L_JAVASCRIPT, L_FORTRAN_77,\
+			   // Don't use L_JS, use L_JAVASCRIPT instead
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};
-enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81};
+
+enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81, WV_WIN10};
 
 
 
-//Here you can find how to use these messages : http://notepad-plus.sourceforge.net/uk/plugins-HOWTO.php 
+//Here you can find how to use these messages : http://docs.notepad-plus-plus.org/index.php/Messages_And_Notifications
 #define NPPMSG  (WM_USER + 1000)
 
 	#define NPPM_GETCURRENTSCINTILLA  (NPPMSG + 4)
@@ -76,7 +80,7 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 
 	#define NPPM_GETOPENFILENAMESPRIMARY (NPPMSG + 17)
 	#define NPPM_GETOPENFILENAMESSECOND (NPPMSG + 18)
-	
+
 	#define NPPM_CREATESCINTILLAHANDLE (NPPMSG + 20)
 	#define NPPM_DESTROYSCINTILLAHANDLE (NPPMSG + 21)
 	#define NPPM_GETNBUSERLANG (NPPMSG + 22)
@@ -103,7 +107,7 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	//ascii file to unicode
 	//int NPPM_ENCODESCI(MAIN_VIEW/SUB_VIEW, 0)
 	//return new unicodeMode
-	
+
 	#define NPPM_DECODESCI (NPPMSG + 27)
 	//unicode file to ascii
 	//int NPPM_DECODESCI(MAIN_VIEW/SUB_VIEW, 0)
@@ -162,7 +166,7 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	//HWND WM_DMM_GETPLUGINHWNDBYNAME(const TCHAR *windowName, const TCHAR *moduleName)
 	// if moduleName is NULL, then return value is NULL
 	// if windowName is NULL, then the first found window handle which matches with the moduleName will be returned
-	
+
 	#define NPPM_MAKECURRENTBUFFERDIRTY (NPPMSG + 44)
 	//BOOL NPPM_MAKECURRENTBUFFERDIRTY(0, 0)
 
@@ -187,13 +191,13 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	// uncomment //#include "menuCmdID.h"
 	// in the beginning of this file then use the command symbols defined in "menuCmdID.h" file
 	// to access all the Notepad++ menu command items
-	
+
 	#define NPPM_TRIGGERTABBARCONTEXTMENU (NPPMSG + 49)
 	//void NPPM_TRIGGERTABBARCONTEXTMENU(int view, int index2Activate)
 
 	#define NPPM_GETNPPVERSION (NPPMSG + 50)
 	// int NPPM_GETNPPVERSION(0, 0)
-	// return version 
+	// return version
 	// ex : v4.6
 	// HIWORD(version) == 4
 	// LOWORD(version) == 6
@@ -213,26 +217,26 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	// Return VIEW|INDEX from a buffer ID. -1 if the bufferID non existing
 	// if priorityView set to SUB_VIEW, then SUB_VIEW will be search firstly
 	//
-	// VIEW takes 2 highest bits and INDEX (0 based) takes the rest (30 bits) 
+	// VIEW takes 2 highest bits and INDEX (0 based) takes the rest (30 bits)
 	// Here's the values for the view :
 	//  MAIN_VIEW 0
 	//  SUB_VIEW  1
 
 	#define NPPM_GETFULLPATHFROMBUFFERID (NPPMSG + 58)
 	// INT NPPM_GETFULLPATHFROMBUFFERID(INT bufferID, TCHAR *fullFilePath)
-	// Get full path file name from a bufferID. 
+	// Get full path file name from a bufferID.
 	// Return -1 if the bufferID non existing, otherwise the number of TCHAR copied/to copy
 	// User should call it with fullFilePath be NULL to get the number of TCHAR (not including the nul character),
 	// allocate fullFilePath with the return values + 1, then call it again to get  full path file name
 
 	#define NPPM_GETBUFFERIDFROMPOS (NPPMSG + 59)
-	// INT NPPM_GETBUFFERIDFROMPOS(INT index, INT iView)
+	// LRESULT NPPM_GETBUFFERIDFROMPOS(INT index, INT iView)
 	// wParam: Position of document
 	// lParam: View to use, 0 = Main, 1 = Secondary
 	// Returns 0 if invalid
 
 	#define NPPM_GETCURRENTBUFFERID (NPPMSG + 60)
-	// INT NPPM_GETCURRENTBUFFERID(0, 0)
+	// LRESULT NPPM_GETCURRENTBUFFERID(0, 0)
 	// Returns active Buffer
 
 	#define NPPM_RELOADBUFFERID (NPPMSG + 61)
@@ -363,7 +367,7 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	// Get programing language name from the given language type (LangType)
 	// Return value is the number of copied character / number of character to copy (\0 is not included)
 	// You should call this function 2 times - the first time you pass langName as NULL to get the number of characters to copy.
-    // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGENAME function the 2nd time 
+    // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGENAME function the 2nd time
 	// by passing allocated buffer as argument langName
 
 	#define NPPM_GETLANGUAGEDESC  (NPPMSG + 84)
@@ -371,7 +375,7 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	// Get programing language short description from the given language type (LangType)
 	// Return value is the number of copied character / number of character to copy (\0 is not included)
 	// You should call this function 2 times - the first time you pass langDesc as NULL to get the number of characters to copy.
-    // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGEDESC function the 2nd time 
+    // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGEDESC function the 2nd time
 	// by passing allocated buffer as argument langDesc
 
 	#define NPPM_SHOWDOCSWITCHER    (NPPMSG + 85)
@@ -403,6 +407,17 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	// INT NPPM_GETEDITORDEFAULTBACKGROUNDCOLOR(0, 0)
 	// Return: current editor default background color. You should convert the returned value in COLORREF
 
+	#define NPPM_SETSMOOTHFONT    (NPPMSG + 92)
+	// VOID NPPM_SETSMOOTHFONT(0, BOOL setSmoothFontOrNot)
+
+	#define NPPM_SETEDITORBORDEREDGE    (NPPMSG + 93)
+	// VOID NPPM_SETEDITORBORDEREDGE(0, BOOL withEditorBorderEdgeOrNot)
+
+	#define NPPM_SAVEFILE (NPPMSG + 94)
+	// VOID NPPM_SAVEFILE(0, const TCHAR *fileNameToSave)
+
+	#define NPPM_DISABLEAUTOUPDATE (NPPMSG + 95) // 2119 in decimal
+	// VOID NPPM_DISABLEAUTOUPDATE(0, 0)
 
 #define	RUNCOMMAND_USER    (WM_USER + 3000)
 	#define NPPM_GETFULLCURRENTPATH		(RUNCOMMAND_USER + FULL_CURRENT_PATH)
@@ -468,12 +483,12 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	//scnNotification->nmhdr.code = NPPN_FILEBEFOREOPEN;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = BufferID;
-	
+
 	#define NPPN_FILEBEFORESAVE (NPPN_FIRST + 7) // To notify plugins that the current file is about to be saved
 	//scnNotification->nmhdr.code = NPPN_FILEBEFOREOPEN;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = BufferID;
-	
+
 	#define NPPN_FILESAVED (NPPN_FIRST + 8) // To notify plugins that the current file is just saved
 	//scnNotification->nmhdr.code = NPPN_FILESAVED;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
@@ -539,6 +554,46 @@ enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV
 	#define NPPN_SNAPSHOTDIRTYFILELOADED (NPPN_FIRST + 18)  // To notify plugins that a snapshot dirty file is loaded on startup
 	//scnNotification->nmhdr.code = NPPN_SNAPSHOTDIRTYFILELOADED;
 	//scnNotification->nmhdr.hwndFrom = NULL;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_BEFORESHUTDOWN (NPPN_FIRST + 19)  // To notify plugins that Npp shutdown has been triggered, files have not been closed yet
+	//scnNotification->nmhdr.code = NPPN_BEFORESHUTDOWN;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = 0;
+
+	#define NPPN_CANCELSHUTDOWN (NPPN_FIRST + 20)  // To notify plugins that Npp shutdown has been cancelled
+	//scnNotification->nmhdr.code = NPPN_CANCELSHUTDOWN;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = 0;
+
+	#define NPPN_FILEBEFORERENAME (NPPN_FIRST + 21)  // To notify plugins that file is to be renamed
+	//scnNotification->nmhdr.code = NPPN_FILEBEFORERENAME;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_FILERENAMECANCEL (NPPN_FIRST + 22)  // To notify plugins that file rename has been cancelled
+	//scnNotification->nmhdr.code = NPPN_FILERENAMECANCEL;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_FILERENAMED (NPPN_FIRST + 23)  // To notify plugins that file has been renamed
+	//scnNotification->nmhdr.code = NPPN_FILERENAMED;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_FILEBEFOREDELETE (NPPN_FIRST + 24)  // To notify plugins that file is to be deleted
+	//scnNotification->nmhdr.code = NPPN_FILEBEFOREDELETE;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_FILEDELETEFAILED (NPPN_FIRST + 25)  // To notify plugins that file deletion has failed
+	//scnNotification->nmhdr.code = NPPN_FILEDELETEFAILED;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = BufferID;
+
+	#define NPPN_FILEDELETED (NPPN_FIRST + 26)  // To notify plugins that file has been deleted
+	//scnNotification->nmhdr.code = NPPN_FILEDELETED;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = BufferID;
 
 #endif //NOTEPAD_PLUS_MSGS_H

--- a/src/npp/PluginInterface.h
+++ b/src/npp/PluginInterface.h
@@ -7,10 +7,10 @@
 // version 2 of the License, or (at your option) any later version.
 //
 // Note that the GPL places important restrictions on "derived works", yet
-// it does not provide a detailed definition of that term.  To avoid      
-// misunderstandings, we consider an application to constitute a          
+// it does not provide a detailed definition of that term.  To avoid
+// misunderstandings, we consider an application to constitute a
 // "derivative work" for the purpose of this license if it does any of the
-// following:                                                             
+// following:
 // 1. Integrates source code from Notepad++.
 // 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
 //    installer, such as those produced by InstallShield.
@@ -45,7 +45,8 @@ const int nbChar = 64;
 
 typedef const TCHAR * (__cdecl * PFUNCGETNAME)();
 
-struct NppData {
+struct NppData
+{
 	HWND _nppHandle;
 	HWND _scintillaMainHandle;
 	HWND _scintillaSecondHandle;
@@ -57,14 +58,16 @@ typedef void (__cdecl * PBENOTIFIED)(SCNotification *);
 typedef LRESULT (__cdecl * PMESSAGEPROC)(UINT Message, WPARAM wParam, LPARAM lParam);
 
 
-struct ShortcutKey {
+struct ShortcutKey
+{
 	bool _isCtrl;
 	bool _isAlt;
 	bool _isShift;
 	UCHAR _key;
 };
 
-struct FuncItem {
+struct FuncItem
+{
 	TCHAR _itemName[nbChar];
 	PFUNCPLUGINCMD _pFunc;
 	int _cmdID;
@@ -81,8 +84,8 @@ extern "C" __declspec(dllexport) FuncItem * getFuncsArray(int *);
 extern "C" __declspec(dllexport) void beNotified(SCNotification *);
 extern "C" __declspec(dllexport) LRESULT messageProc(UINT Message, WPARAM wParam, LPARAM lParam);
 
-#ifdef UNICODE
+// This API return always true now, since Notepad++ isn't compiled in ANSI mode anymore
 extern "C" __declspec(dllexport) BOOL isUnicode();
-#endif //UNICODE
+
 
 #endif //PLUGININTERFACE_H

--- a/src/npp/Scintilla.h
+++ b/src/npp/Scintilla.h
@@ -18,9 +18,9 @@ extern "C" {
 #if defined(_WIN32)
 /* Return false on failure: */
 int Scintilla_RegisterClasses(void *hInstance);
-int Scintilla_ReleaseResources();
+int Scintilla_ReleaseResources(void);
 #endif
-int Scintilla_LinkLexers();
+int Scintilla_LinkLexers(void);
 
 #ifdef __cplusplus
 }
@@ -50,6 +50,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_ADDTEXT 2001
 #define SCI_ADDSTYLEDTEXT 2002
 #define SCI_INSERTTEXT 2003
+#define SCI_CHANGEINSERTION 2672
 #define SCI_CLEARALL 2004
 #define SCI_DELETERANGE 2645
 #define SCI_CLEARDOCUMENTSTYLE 2005
@@ -91,8 +92,15 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_SETBUFFEREDDRAW 2035
 #define SCI_SETTABWIDTH 2036
 #define SCI_GETTABWIDTH 2121
+#define SCI_CLEARTABSTOPS 2675
+#define SCI_ADDTABSTOP 2676
+#define SCI_GETNEXTTABSTOP 2677
 #define SC_CP_UTF8 65001
 #define SCI_SETCODEPAGE 2037
+#define SC_IME_WINDOWED 0
+#define SC_IME_INLINE 1
+#define SCI_GETIMEINTERACTION 2678
+#define SCI_SETIMEINTERACTION 2679
 #define MARKER_MAX 31
 #define SC_MARK_CIRCLE 0
 #define SC_MARK_ROUNDRECT 1
@@ -125,6 +133,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_MARK_AVAILABLE 28
 #define SC_MARK_UNDERLINE 29
 #define SC_MARK_RGBAIMAGE 30
+#define SC_MARK_BOOKMARK 31
 #define SC_MARK_CHARACTER 10000
 #define SC_MARKNUM_FOLDEREND 25
 #define SC_MARKNUM_FOLDEROPENMID 26
@@ -265,7 +274,12 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define INDIC_DOTBOX 12
 #define INDIC_SQUIGGLEPIXMAP 13
 #define INDIC_COMPOSITIONTHICK 14
-#define INDIC_MAX 31
+#define INDIC_COMPOSITIONTHIN 15
+#define INDIC_FULLBOX 16
+#define INDIC_TEXTFORE 17
+#define INDIC_IME 32
+#define INDIC_IME_MAX 35
+#define INDIC_MAX 35
 #define INDIC_CONTAINER 8
 #define INDIC0_MASK 0x20
 #define INDIC1_MASK 0x40
@@ -277,6 +291,15 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_INDICGETFORE 2083
 #define SCI_INDICSETUNDER 2510
 #define SCI_INDICGETUNDER 2511
+#define SCI_INDICSETHOVERSTYLE 2680
+#define SCI_INDICGETHOVERSTYLE 2681
+#define SCI_INDICSETHOVERFORE 2682
+#define SCI_INDICGETHOVERFORE 2683
+#define SC_INDICVALUEBIT 0x1000000
+#define SC_INDICVALUEMASK 0xFFFFFF
+#define SC_INDICFLAG_VALUEFORE 1
+#define SCI_INDICSETFLAGS 2684
+#define SCI_INDICGETFLAGS 2685
 #define SCI_SETWHITESPACEFORE 2084
 #define SCI_SETWHITESPACEBACK 2085
 #define SCI_SETWHITESPACESIZE 2086
@@ -358,11 +381,12 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_PRINT_COLOURONWHITEDEFAULTBG 4
 #define SCI_SETPRINTCOLOURMODE 2148
 #define SCI_GETPRINTCOLOURMODE 2149
-#define SCFIND_WHOLEWORD 2
-#define SCFIND_MATCHCASE 4
+#define SCFIND_WHOLEWORD 0x2
+#define SCFIND_MATCHCASE 0x4
 #define SCFIND_WORDSTART 0x00100000
 #define SCFIND_REGEXP 0x00200000
 #define SCFIND_POSIX 0x00400000
+#define SCFIND_CXX11REGEX 0x00800000
 #define SCI_FINDTEXT 2150
 #define SCI_FORMATRANGE 2151
 #define SCI_GETFIRSTVISIBLELINE 2152
@@ -408,6 +432,8 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_GETTARGETSTART 2191
 #define SCI_SETTARGETEND 2192
 #define SCI_GETTARGETEND 2193
+#define SCI_SETTARGETRANGE 2686
+#define SCI_GETTARGETTEXT 2687
 #define SCI_REPLACETARGET 2194
 #define SCI_REPLACETARGETRE 2195
 #define SCI_SEARCHINTARGET 2197
@@ -417,6 +443,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_CALLTIPCANCEL 2201
 #define SCI_CALLTIPACTIVE 2202
 #define SCI_CALLTIPPOSSTART 2203
+#define SCI_CALLTIPSETPOSSTART 2214
 #define SCI_CALLTIPSETHLT 2204
 #define SCI_CALLTIPSETBACK 2205
 #define SCI_CALLTIPSETFORE 2206
@@ -459,6 +486,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_FOLDFLAG_LINEAFTER_EXPANDED 0x0008
 #define SC_FOLDFLAG_LINEAFTER_CONTRACTED 0x0010
 #define SC_FOLDFLAG_LEVELNUMBERS 0x0040
+#define SC_FOLDFLAG_LINESTATE 0x0080
 #define SCI_SETFOLDFLAGS 2233
 #define SCI_ENSUREVISIBLEENFORCEPOLICY 2234
 #define SCI_SETTABINDENTS 2260
@@ -473,6 +501,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_WRAP_NONE 0
 #define SC_WRAP_WORD 1
 #define SC_WRAP_CHAR 2
+#define SC_WRAP_WHITESPACE 3
 #define SCI_SETWRAPMODE 2268
 #define SCI_GETWRAPMODE 2269
 #define SC_WRAPVISUALFLAG_NONE 0x0000
@@ -512,6 +541,11 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_APPENDTEXT 2282
 #define SCI_GETTWOPHASEDRAW 2283
 #define SCI_SETTWOPHASEDRAW 2284
+#define SC_PHASES_ONE 0
+#define SC_PHASES_TWO 1
+#define SC_PHASES_MULTIPLE 2
+#define SCI_GETPHASESDRAW 2673
+#define SCI_SETPHASESDRAW 2674
 #define SC_EFF_QUALITY_MASK 0xF
 #define SC_EFF_QUALITY_DEFAULT 0
 #define SC_EFF_QUALITY_NON_ANTIALIASED 1
@@ -626,6 +660,8 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_STATUS_OK 0
 #define SC_STATUS_FAILURE 1
 #define SC_STATUS_BADALLOC 2
+#define SC_STATUS_WARN_START 1000
+#define SC_STATUS_WARN_REGEX 1001
 #define SCI_SETSTATUS 2382
 #define SCI_GETSTATUS 2383
 #define SCI_SETMOUSEDOWNCAPTURES 2384
@@ -673,6 +709,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_PARAUPEXTEND 2416
 #define SCI_POSITIONBEFORE 2417
 #define SCI_POSITIONAFTER 2418
+#define SCI_POSITIONRELATIVE 2670
 #define SCI_COPYRANGE 2419
 #define SCI_COPYTEXT 2420
 #define SC_SEL_STREAM 0
@@ -711,6 +748,10 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_CASEINSENSITIVEBEHAVIOUR_IGNORECASE 1
 #define SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR 2634
 #define SCI_AUTOCGETCASEINSENSITIVEBEHAVIOUR 2635
+#define SC_MULTIAUTOC_ONCE 0
+#define SC_MULTIAUTOC_EACH 1
+#define SCI_AUTOCSETMULTI 2636
+#define SCI_AUTOCGETMULTI 2637
 #define SC_ORDER_PRESORTED 0
 #define SC_ORDER_PERFORMSORT 1
 #define SC_ORDER_CUSTOM 2
@@ -756,8 +797,6 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_GETCHARACTERPOINTER 2520
 #define SCI_GETRANGEPOINTER 2643
 #define SCI_GETGAPPOSITION 2644
-#define SCI_SETKEYSUNICODE 2521
-#define SCI_GETKEYSUNICODE 2522
 #define SCI_INDICSETALPHA 2523
 #define SCI_INDICGETALPHA 2524
 #define SCI_INDICSETOUTLINEALPHA 2558
@@ -791,6 +830,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define ANNOTATION_HIDDEN 0
 #define ANNOTATION_STANDARD 1
 #define ANNOTATION_BOXED 2
+#define ANNOTATION_INDENTED 3
 #define SCI_ANNOTATIONSETVISIBLE 2548
 #define SCI_ANNOTATIONGETVISIBLE 2549
 #define SCI_ANNOTATIONSETSTYLEOFFSET 2550
@@ -801,6 +841,8 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_ADDUNDOACTION 2560
 #define SCI_CHARPOSITIONFROMPOINT 2561
 #define SCI_CHARPOSITIONFROMPOINTCLOSE 2562
+#define SCI_SETMOUSESELECTIONRECTANGULARSWITCH 2668
+#define SCI_GETMOUSESELECTIONRECTANGULARSWITCH 2669
 #define SCI_SETMULTIPLESELECTION 2563
 #define SCI_GETMULTIPLESELECTION 2564
 #define SCI_SETADDITIONALSELECTIONTYPING 2565
@@ -814,6 +856,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_CLEARSELECTIONS 2571
 #define SCI_SETSELECTION 2572
 #define SCI_ADDSELECTION 2573
+#define SCI_DROPSELECTIONN 2671
 #define SCI_SETMAINSELECTION 2574
 #define SCI_GETMAINSELECTION 2575
 #define SCI_SETSELECTIONNCARET 2576
@@ -867,6 +910,8 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_SCROLLTOEND 2629
 #define SC_TECHNOLOGY_DEFAULT 0
 #define SC_TECHNOLOGY_DIRECTWRITE 1
+#define SC_TECHNOLOGY_DIRECTWRITERETAIN 2
+#define SC_TECHNOLOGY_DIRECTWRITEDC 3
 #define SCI_SETTECHNOLOGY 2630
 #define SCI_GETTECHNOLOGY 2631
 #define SCI_CREATELOADER 2632
@@ -877,6 +922,14 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_VCHOMEDISPLAYEXTEND 2653
 #define SCI_GETCARETLINEVISIBLEALWAYS 2654
 #define SCI_SETCARETLINEVISIBLEALWAYS 2655
+#define SC_LINE_END_TYPE_DEFAULT 0
+#define SC_LINE_END_TYPE_UNICODE 1
+#define SCI_SETLINEENDTYPESALLOWED 2656
+#define SCI_GETLINEENDTYPESALLOWED 2657
+#define SCI_GETLINEENDTYPESACTIVE 2658
+#define SCI_SETREPRESENTATION 2665
+#define SCI_GETREPRESENTATION 2666
+#define SCI_CLEARREPRESENTATION 2667
 #define SCI_STARTRECORD 3001
 #define SCI_STOPRECORD 3002
 #define SCI_SETLEXER 4001
@@ -901,6 +954,16 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_PROPERTYTYPE 4015
 #define SCI_DESCRIBEPROPERTY 4016
 #define SCI_DESCRIBEKEYWORDSETS 4017
+#define SCI_GETLINEENDTYPESSUPPORTED 4018
+#define SCI_ALLOCATESUBSTYLES 4020
+#define SCI_GETSUBSTYLESSTART 4021
+#define SCI_GETSUBSTYLESLENGTH 4022
+#define SCI_GETSTYLEFROMSUBSTYLE 4027
+#define SCI_GETPRIMARYSTYLEFROMSTYLE 4028
+#define SCI_FREESUBSTYLES 4023
+#define SCI_SETIDENTIFIERS 4024
+#define SCI_DISTANCETOSECONDARYSTYLES 4025
+#define SCI_GETSUBSTYLEBASES 4026
 #define SC_MOD_INSERTTEXT 0x1
 #define SC_MOD_DELETETEXT 0x2
 #define SC_MOD_CHANGESTYLE 0x4
@@ -921,7 +984,9 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SC_MOD_CHANGEANNOTATION 0x20000
 #define SC_MOD_CONTAINER 0x40000
 #define SC_MOD_LEXERSTATE 0x80000
-#define SC_MODEVENTMASKALL 0xFFFFF
+#define SC_MOD_INSERTCHECK 0x100000
+#define SC_MOD_CHANGETABSTOPS 0x200000
+#define SC_MODEVENTMASKALL 0x3FFFFF
 #define SC_SEARCHRESULT_LINEBUFFERMAXLENGTH 1024
 #define SC_UPDATE_CONTENT 0x1
 #define SC_UPDATE_SELECTION 0x2
@@ -983,30 +1048,17 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCN_AUTOCCANCELLED 2025
 #define SCN_AUTOCCHARDELETED 2026
 #define SCN_HOTSPOTRELEASECLICK 2027
-#ifndef SCI_DISABLE_PROVISIONAL
-#define SC_LINE_END_TYPE_DEFAULT 0
-#define SC_LINE_END_TYPE_UNICODE 1
-#define SCI_SETLINEENDTYPESALLOWED 2656
-#define SCI_GETLINEENDTYPESALLOWED 2657
-#define SCI_GETLINEENDTYPESACTIVE 2658
-#define SCI_GETLINEENDTYPESSUPPORTED 4018
-#define SCI_ALLOCATESUBSTYLES 4020
-#define SCI_GETSUBSTYLESSTART 4021
-#define SCI_GETSUBSTYLESLENGTH 4022
-#define SCI_FREESUBSTYLES 4023
-#define SCI_SETIDENTIFIERS 4024
-#define SCI_DISTANCETOSECONDARYSTYLES 4025
-#define SCI_GETSUBSTYLEBASES 4026
+#define SCN_FOCUSIN 2028
+#define SCN_FOCUSOUT 2029
 #define SCN_SCROLLED 2080
 #define SCN_FOLDINGSTATECHANGED 2081
-#endif
 /* --Autogenerated -- end of section automatically generated from Scintilla.iface */
 
 /* These structures are defined to be exactly the same shape as the Win32
  * CHARRANGE, TEXTRANGE, FINDTEXTEX, FORMATRANGE, and NMHDR structs.
  * So older code that treats Scintilla as a RichEdit will work. */
 
-#ifdef SCI_NAMESPACE
+#if defined(__cplusplus) && defined(SCI_NAMESPACE)
 namespace Scintilla {
 #endif
 
@@ -1022,7 +1074,7 @@ struct Sci_TextRange {
 
 struct Sci_TextToFind {
 	struct Sci_CharacterRange chrg;
-	char *lpstrText;
+	const char *lpstrText;
 	struct Sci_CharacterRange chrgText;
 };
 
@@ -1108,7 +1160,7 @@ struct SearchResultMarkings {
 	SearchResultMarking *_markings;
 };
 
-#ifdef SCI_NAMESPACE
+#if defined(__cplusplus) && defined(SCI_NAMESPACE)
 }
 #endif
 
@@ -1117,6 +1169,8 @@ struct SearchResultMarkings {
 #define SC_CP_DBCS 1
 #define SCI_SETUSEPALETTE 2039
 #define SCI_GETUSEPALETTE 2139
+#define SCI_SETKEYSUNICODE 2521
+#define SCI_GETKEYSUNICODE 2522
 
 #endif
 

--- a/src/npp/menuCmdID.h
+++ b/src/npp/menuCmdID.h
@@ -54,37 +54,41 @@
     #define    IDM_FILE_CLOSEALL_TORIGHT        (IDM_FILE + 18)
     #define    IDM_FILE_OPEN_FOLDER             (IDM_FILE + 19)
     #define    IDM_FILE_OPEN_CMD                (IDM_FILE + 20)
+	#define    IDM_FILE_RESTORELASTCLOSEDFILE   (IDM_FILE + 21)
+	#define    IDM_FILE_OPENFOLDERASWORSPACE    (IDM_FILE + 22)
 // IMPORTANT: If list above is modified, you have to change the following values:
  
 // To be updated if new menu item(s) is (are) added in menu "File"
-    #define    IDM_FILEMENU_LASTONE             IDM_FILE_OPEN_CMD
-	
+    #define    IDM_FILEMENU_LASTONE             IDM_FILE_OPENFOLDERASWORSPACE
+
 // 0 based position of command "Exit" including the bars in the file menu
 // and without counting "Recent files history" items
 
 // 0  New
 // 1  Open...
-// 2  Open Folder
-// 3  Reload from Disk
-// 4  Save
-// 5  Save As...
-// 6  Save a Copy As...
-// 7  Save All
-// 8  Rename...
-// 9  Close
-//10  Close All
-//11  Close More
-//12  Move to Recycle Bin
-//13  --------
-//14  Load Session...
-//15  Save Session...
-//16  --------
-//17  Print...
-//18  Print Now
-//19  --------
-//20  Exit
-    #define    IDM_FILEMENU_EXISTCMDPOSITION    20 
- 
+// 2  Open Containing Folder
+// 3  Open Folder as Workspace
+// 4  Reload from Disk
+// 5  Save
+// 6  Save As...
+// 7  Save a Copy As...
+// 8  Save All
+// 9  Rename...
+//10  Close
+//11  Close All
+//12  Close More
+//13  Move to Recycle Bin
+//14  --------
+//15  Load Session...
+//16  Save Session...
+//17  --------
+//18  Print...
+//19  Print Now
+//20  --------
+//21  Exit
+    #define    IDM_FILEMENU_EXISTCMDPOSITION    21
+
+
 #define    IDM_EDIT       (IDM + 2000)
     #define    IDM_EDIT_CUT                         (IDM_EDIT + 1) 
     #define    IDM_EDIT_COPY                        (IDM_EDIT + 2)
@@ -109,8 +113,14 @@
     #define    IDM_EDIT_REMOVEEMPTYLINESWITHBLANK   (IDM_EDIT + 56)
     #define    IDM_EDIT_BLANKLINEABOVECURRENT       (IDM_EDIT + 57)
     #define    IDM_EDIT_BLANKLINEBELOWCURRENT       (IDM_EDIT + 58)
-    #define    IDM_EDIT_SORTLINES                   (IDM_EDIT + 59)
-    #define    IDM_EDIT_SORTLINESREVERSE            (IDM_EDIT + 60)
+	#define    IDM_EDIT_SORTLINES_LEXICOGRAPHIC_ASCENDING	(IDM_EDIT + 59)
+	#define    IDM_EDIT_SORTLINES_LEXICOGRAPHIC_DESCENDING	(IDM_EDIT + 60)
+	#define    IDM_EDIT_SORTLINES_INTEGER_ASCENDING			(IDM_EDIT + 61)
+	#define    IDM_EDIT_SORTLINES_INTEGER_DESCENDING		(IDM_EDIT + 62)
+	#define    IDM_EDIT_SORTLINES_DECIMALCOMMA_ASCENDING	(IDM_EDIT + 63)
+	#define    IDM_EDIT_SORTLINES_DECIMALCOMMA_DESCENDING	(IDM_EDIT + 64)
+	#define    IDM_EDIT_SORTLINES_DECIMALDOT_ASCENDING		(IDM_EDIT + 65)
+	#define    IDM_EDIT_SORTLINES_DECIMALDOT_DESCENDING		(IDM_EDIT + 66)
 
 // Menu macro
     #define    IDM_MACRO_STARTRECORDINGMACRO        (IDM_EDIT + 18)
@@ -222,6 +232,7 @@
 	#define    IDM_SEARCH_DELETEUNMARKEDLINES  (IDM_SEARCH + 51)
 	#define    IDM_SEARCH_FINDCHARINRANGE      (IDM_SEARCH + 52)
 	#define    IDM_SEARCH_SELECTMATCHINGBRACES (IDM_SEARCH + 53)
+	#define    IDM_SEARCH_MARK                 (IDM_SEARCH + 54)
 	
 #define    IDM_MISC    (IDM + 3500)
 	#define    IDM_FILESWITCHER_FILESCLOSE            (IDM_MISC + 1)
@@ -309,7 +320,8 @@
 	#define    IDM_VIEW_PROJECT_PANEL_3           (IDM_VIEW + 83)
 
 	#define    IDM_VIEW_FUNC_LIST                 (IDM_VIEW + 84)
-	
+	#define    IDM_VIEW_FILEBROWSER               (IDM_VIEW + 85)
+
 	#define	   IDM_VIEW_TAB1					  (IDM_VIEW + 86)
 	#define	   IDM_VIEW_TAB2					  (IDM_VIEW + 87)
 	#define	   IDM_VIEW_TAB3					  (IDM_VIEW + 88)
@@ -321,6 +333,7 @@
 	#define	   IDM_VIEW_TAB9					  (IDM_VIEW + 94)
 	#define	   IDM_VIEW_TAB_NEXT				  (IDM_VIEW + 95)
 	#define	   IDM_VIEW_TAB_PREV				  (IDM_VIEW + 96)
+    #define    IDM_VIEW_MONITORING                (IDM_VIEW + 97)
 
     #define    IDM_VIEW_GOTO_ANOTHER_VIEW        10001
     #define    IDM_VIEW_CLONE_TO_ANOTHER_VIEW    10002
@@ -454,6 +467,8 @@
     #define    IDM_LANG_R                  (IDM_LANG + 54)
     #define    IDM_LANG_JSP                (IDM_LANG + 55)
 	#define    IDM_LANG_COFFEESCRIPT       (IDM_LANG + 56)
+	#define    IDM_LANG_JSON		       (IDM_LANG + 57)
+    #define    IDM_LANG_FORTRAN_77         (IDM_LANG + 58)
 
     #define    IDM_LANG_EXTERNAL           (IDM_LANG + 65)
     #define    IDM_LANG_EXTERNAL_LIMIT     (IDM_LANG + 79)
@@ -475,6 +490,8 @@
     #define    IDM_HELP             (IDM_ABOUT  + 8)
 	#define    IDM_CONFUPDATERPROXY (IDM_ABOUT  + 9)
 	#define    IDM_CMDLINEARGUMENTS (IDM_ABOUT  + 10)
+	#define    IDM_ONLINESUPPORT    (IDM_ABOUT  + 11)
+	#define    IDM_DEBUGINFO        (IDM_ABOUT  + 12)
 
 
 #define    IDM_SETTING    (IDM + 8000)

--- a/src/res/version.h
+++ b/src/res/version.h
@@ -17,8 +17,8 @@
 #define NPP_PLUGIN_VERSION_H
 
 
-#define RES_VERSION_B  1,4,3,0
-#define RES_VERSION_S  "1.4.3.0"
+#define RES_VERSION_B  1,4,4,0
+#define RES_VERSION_S  "1.4.4.0"
 #define PLUGIN_VERSION _W(RES_VERSION_S)
 #define RES_COPYRIGHT  "Copyright 2011-2015 Michael Foster. Distributed under the terms of the GNU GPL."
 

--- a/src/res/version.h
+++ b/src/res/version.h
@@ -17,8 +17,8 @@
 #define NPP_PLUGIN_VERSION_H
 
 
-#define RES_VERSION_B  1,4,2,0
-#define RES_VERSION_S  "1.4.2.0"
+#define RES_VERSION_B  1,4,3,0
+#define RES_VERSION_S  "1.4.3.0"
 #define PLUGIN_VERSION _W(RES_VERSION_S)
 #define RES_COPYRIGHT  "Copyright 2011-2015 Michael Foster. Distributed under the terms of the GNU GPL."
 


### PR DESCRIPTION
- added appveyor.yml with preparation for automatic github deloyment (just release builds are possible with the available nmake makefile), vs2015 compilers are used with this config
- updated npp include files to v3.1 from https://github.com/npp-plugins/plugintemplate, modified PluginInterface.h to include menuCmdID.h as before
- changed makefile for x64 build
- updated bufferid references from INT -> LRESULT
- fixed issue https://notepad-plus-plus.org/community/topic/12558/session-manager-issue by usage of fix from https://github.com/pnedev/npp-session-manager

see appveyor CI build https://ci.appveyor.com/project/chcg/npp-session-manager/build/1.4.2.5